### PR TITLE
feat: Add memory-only terminal mode with --keep-mermaid-files flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,13 +64,14 @@ mdviewer document.md --width 100
 mdviewer document.md --no-mermaid
 
 # Mermaid rendering modes
-mdviewer document.md --mermaid-mode=terminal  # Default: ASCII preview + SVG export
-mdviewer document.md --mermaid-mode=svg       # Export SVGs only
-mdviewer document.md --mermaid-mode=png       # Export PNGs only
+mdviewer document.md --mermaid-mode=terminal  # Default: Memory-only (inline or ASCII preview)
+mdviewer document.md --mermaid-mode=svg       # Export SVGs to temp directory
+mdviewer document.md --mermaid-mode=png       # Export PNGs to temp directory
 mdviewer document.md --mermaid-mode=url       # Show URLs + code (no local rendering)
 
-# Custom SVG output directory
-mdviewer document.md --mermaid-output-dir=./diagrams
+# Save Mermaid diagrams to disk (terminal mode only)
+mdviewer document.md --keep-mermaid-files     # Saves SVG files to temp directory
+mdviewer document.md -k --mermaid-output-dir=./diagrams  # Save to custom directory
 
 # Export to PDF
 mdviewer document.md --export-pdf output.pdf
@@ -111,7 +112,7 @@ graph TD
 ### Rendering Modes
 
 #### Terminal Mode (Default)
-Displays diagrams inline (if your terminal supports it) or as an ASCII preview box, and saves SVG files:
+Displays diagrams inline (if your terminal supports it) or as an ASCII preview box. **Files are kept in memory by default** - no disk files are created unless you use `--keep-mermaid-files`:
 
 **Inline Image Support** (auto-detected):
 - ✅ **Warp Terminal** (iTerm2 protocol)
@@ -125,7 +126,6 @@ If your terminal supports inline images, diagrams will render directly in the ou
 ```
 📊 Mermaid Diagram (Flowchart):
 [actual rendered image appears here]
-  💾 Saved to: diagram-1.svg
 ```
 
 Otherwise, you'll see an ASCII info box:
@@ -135,19 +135,35 @@ Otherwise, you'll see an ASCII info box:
 │ 📐 Dimensions: 232x334 px                        │
 │ ✅ Rendered locally                              │
 └──────────────────────────────────────────────────┘
-  💾 Saved to: diagram-1.svg
+```
+
+**To save diagrams to disk**, use the `--keep-mermaid-files` flag:
+```bash
+mdviewer doc.md --keep-mermaid-files
+# Files saved to system temp directory by default
+
+mdviewer doc.md -k --mermaid-output-dir=./my-diagrams
+# Files saved to custom directory
 ```
 
 #### SVG Mode
-Only exports SVG files (no terminal preview):
+Exports SVG files to disk (no terminal preview):
 ```bash
+mdviewer doc.md --mermaid-mode=svg
+# Files saved to system temp directory
+
 mdviewer doc.md --mermaid-mode=svg --mermaid-output-dir=./diagrams
+# Files saved to custom directory
 ```
 
 #### PNG Mode
-Exports diagrams as PNG images:
+Exports diagrams as PNG images to disk:
 ```bash
+mdviewer doc.md --mermaid-mode=png
+# Files saved to system temp directory
+
 mdviewer doc.md --mermaid-mode=png --mermaid-output-dir=./diagrams
+# Files saved to custom directory
 ```
 
 #### URL Mode (Fallback)

--- a/WARP.md
+++ b/WARP.md
@@ -1,0 +1,228 @@
+# WARP.md
+
+This file provides guidance to WARP (warp.dev) when working with code in this repository.
+
+## Project Overview
+
+`mdviewer` is a cross-platform terminal markdown viewer with local Mermaid diagram rendering, built in Go. It renders markdown files with beautiful ANSI styling directly in the terminal and can export to PDF.
+
+**Key Features:**
+- Terminal markdown rendering with multiple themes (via Glamour)
+- Local Mermaid diagram rendering using headless Chrome (chromedp)
+- Stdin support for piping markdown content
+- PDF export with rendered diagrams
+- Cross-platform support (macOS, Linux, Windows)
+
+## Prerequisites
+
+- **Go 1.21+** (currently using Go 1.25.0)
+- **Chrome/Chromium** installed on the system for Mermaid rendering and PDF export (chromedp requirement)
+  - Without Chrome, the tool falls back to URL mode for Mermaid diagrams
+
+## Development Commands
+
+### Building
+```bash
+# Build the binary
+go build -o mdviewer ./cmd/mdviewer
+
+# Build for all platforms
+./build.sh
+
+# Build with specific version
+./build.sh 1.0.0
+```
+
+### Running
+```bash
+# Run directly with go
+go run ./cmd/mdviewer <file>
+
+# Run the compiled binary
+./mdviewer README.md
+
+# View with specific options
+./mdviewer test.md --style dark --mermaid-mode terminal
+
+# Save Mermaid diagrams to disk (terminal mode only)
+./mdviewer test.md --keep-mermaid-files
+./mdviewer test.md -k --mermaid-output-dir=./diagrams
+```
+
+### Testing
+```bash
+# Run all tests
+go test ./...
+
+# Verbose test output
+go test -v ./...
+
+# Test a specific package
+go test ./internal/renderer
+```
+
+**Note:** Currently no test files exist in the codebase.
+
+### Dependency Management
+```bash
+# Download dependencies
+go mod download
+
+# Tidy up dependencies
+go mod tidy
+
+# Update all dependencies
+go get -u ./...
+```
+
+## Architecture
+
+### Entry Point
+- **`cmd/mdviewer/main.go`**: CLI entry point using Cobra framework
+  - Defines command-line flags and options
+  - Handles input from files or stdin
+  - Routes to viewer or PDF export based on flags
+
+### Core Components
+
+#### 1. Renderer (`internal/renderer/`)
+Handles markdown rendering with multiple output formats:
+- **`markdown.go`**: Main renderer using Glamour for ANSI terminal output
+- **`html.go`**: HTML renderer using Goldmark (for PDF export)
+- **`mermaid.go`**: Mermaid diagram detection and URL generation
+- **`styles.go`**: Custom style definitions (clean style without hash prefixes)
+
+**Key Pattern**: The renderer processes markdown in two stages:
+1. Detect and process Mermaid blocks (if enabled)
+2. Render to target format (ANSI or HTML)
+
+#### 2. Mermaid Compiler (`internal/mermaid/`)
+Local Mermaid rendering engine using headless Chrome:
+- **`compiler.go`**: Core chromedp-based rendering logic
+  - Creates fresh browser contexts per render (prevents memory leaks)
+  - Renders diagrams to SVG or PNG
+  - 30-second timeout per diagram
+- **`embed.go`**: Embeds mermaid.min.js using go:embed
+- **`svg.go`**: SVG utilities (cleaning, dimension extraction)
+
+**Important**: Each render creates a fresh chromedp context and cancels it when done to prevent resource leaks.
+
+#### 3. PDF Exporter (`internal/pdf/`)
+PDF generation using chromedp:
+- **`exporter.go`**: High-level export interface
+- **`chromedp.go`**: Low-level chromedp PDF generation
+- Converts markdown → HTML → PDF with rendered Mermaid diagrams
+
+#### 4. Viewer (`internal/viewer/`)
+Display logic for terminal output:
+- **`simple.go`**: Simple viewer that reads files or stdin and displays rendered output
+
+#### 5. Utilities (`internal/utils/`)
+Helper functions:
+- **`terminal.go`**: Terminal width detection
+- **`termimg.go`**: Terminal inline image support detection (iTerm2, Kitty protocols)
+- **`file.go`**: File I/O utilities
+- **`browser.go`**: Browser launch utilities for Mermaid URLs
+
+### Key Technology Stack
+- **Glamour**: Terminal markdown rendering with ANSI styling
+- **Cobra**: CLI framework for command-line interface
+- **Goldmark**: Markdown parser (for HTML rendering)
+- **Chromedp**: Headless Chrome automation (for Mermaid and PDF)
+
+### Data Flow
+
+1. **Terminal Viewing**:
+   ```
+   Input (file/stdin) → Renderer (Glamour) → Mermaid Detector → 
+   Local Mermaid Renderer (chromedp) → Terminal Display
+   ```
+
+2. **PDF Export**:
+   ```
+   Input → HTML Renderer (Goldmark) → Mermaid Renderer (chromedp) → 
+   PDF Generator (chromedp) → File Output
+   ```
+
+## Mermaid Rendering Modes
+
+The tool supports multiple rendering modes (via `--mermaid-mode`):
+
+- **`terminal`** (default): Display inline images if terminal supports it, otherwise ASCII preview. **Memory-only by default** - no files created unless `--keep-mermaid-files` is used.
+- **`svg`**: Export SVG files to disk (temp directory by default)
+- **`png`**: Export PNG files to disk (temp directory by default)
+- **`url`**: Show clickable URLs to mermaid.live and mermaid.ink (fallback when Chrome unavailable)
+
+### File Management
+
+- **Default behavior**: Terminal mode works entirely in memory (no files created)
+- **`--keep-mermaid-files` / `-k`**: Save diagram files to disk in terminal mode
+- **Default output directory**: System temp directory (`os.TempDir()`)
+- **Custom output directory**: Use `--mermaid-output-dir=/path/to/dir`
+- **SVG/PNG export modes**: Always save files (this is their purpose)
+
+## Important Code Patterns
+
+### Chromedp Context Management
+Always create fresh contexts and defer cancellation:
+```go
+ctx, cancel := chromedp.NewContext(context.Background())
+defer cancel()
+```
+
+### Style Selection
+The renderer supports multiple style modes:
+- Built-in: `auto`, `dark`, `light`, `clean` (custom without hash prefixes)
+- Custom: Path to a Glamour style JSON file
+
+### Mermaid Block Detection
+Uses regex to find mermaid code blocks and extracts:
+- Diagram type
+- Source code
+- Line numbers (for insertion of indicators)
+
+## Release Process
+
+Releases are automated via GitHub Actions (`.github/workflows/release.yml`):
+1. Push a version tag: `git tag v1.0.0 && git push origin v1.0.0`
+2. GitHub Actions builds binaries for all platforms
+3. Creates GitHub release with binaries and checksums
+
+**Supported Platforms**:
+- macOS (Intel and Apple Silicon)
+- Linux (AMD64 and ARM64)
+- Windows (AMD64)
+
+## Common Development Tasks
+
+### Adding a New CLI Flag
+1. Add flag variable in `cmd/mdviewer/main.go` (global vars)
+2. Register flag in `init()` function
+3. Pass flag value through `RenderOptions` or use directly
+4. Update help text in Cobra command definition
+
+### Adding a New Rendering Mode
+1. Define mode constant in `internal/mermaid/compiler.go`
+2. Update mode handling in `internal/renderer/markdown.go`
+3. Add flag documentation in `cmd/mdviewer/main.go`
+
+### Debugging Chromedp Issues
+- Check Chrome/Chromium installation
+- Increase timeout values if diagrams are timing out
+- Use chromedp debug logging (not currently enabled)
+- Verify mermaid.min.js is properly embedded
+
+## Testing Approach
+
+When writing tests:
+- Mock chromedp for Mermaid rendering tests (avoid real browser dependency)
+- Test markdown rendering with known inputs
+- Test style selection and width detection
+- Use table-driven tests for multiple scenarios
+
+## Dependencies Update Strategy
+
+- Keep Go toolchain up to date (currently on 1.25.0)
+- Update Glamour for terminal rendering improvements
+- Update chromedp for Chrome compatibility
+- Pin Goldmark and other parsers to stable versions

--- a/cmd/mdviewer/main.go
+++ b/cmd/mdviewer/main.go
@@ -13,13 +13,14 @@ import (
 
 var (
 	// Global flags
-	style         string
-	width         int
-	noMermaid     bool
-	openMermaid   bool
-	exportPDF     string
-	mermaidMode   string
-	mermaidOutDir string
+	style            string
+	width            int
+	noMermaid        bool
+	openMermaid      bool
+	exportPDF        string
+	mermaidMode      string
+	mermaidOutDir    string
+	keepMermaidFiles bool
 )
 
 func main() {
@@ -55,7 +56,8 @@ func init() {
 	rootCmd.Flags().BoolVar(&openMermaid, "open-mermaid", false, "Open mermaid diagrams in browser automatically")
 	rootCmd.Flags().StringVarP(&exportPDF, "export-pdf", "p", "", "Export to PDF file")
 	rootCmd.Flags().StringVar(&mermaidMode, "mermaid-mode", "terminal", "Mermaid rendering mode: terminal (default), svg, png, url")
-	rootCmd.Flags().StringVar(&mermaidOutDir, "mermaid-output-dir", ".", "Directory for exported SVG files (default: current directory)")
+	rootCmd.Flags().StringVar(&mermaidOutDir, "mermaid-output-dir", os.TempDir(), "Directory for exported diagram files (default: system temp directory)")
+	rootCmd.Flags().BoolVarP(&keepMermaidFiles, "keep-mermaid-files", "k", false, "Save Mermaid diagram files (SVG/PNG) to disk")
 }
 
 func runView(cmd *cobra.Command, args []string) error {
@@ -80,11 +82,12 @@ func runView(cmd *cobra.Command, args []string) error {
 
 	// Create renderer
 	rendererOpts := renderer.RenderOptions{
-		Style:       style,
-		Width:       width,
-		NoMermaid:   noMermaid,
-		MermaidMode: mermaidMode,
-		MermaidOutDir: mermaidOutDir,
+		Style:            style,
+		Width:            width,
+		NoMermaid:        noMermaid,
+		MermaidMode:      mermaidMode,
+		MermaidOutDir:    mermaidOutDir,
+		KeepMermaidFiles: keepMermaidFiles,
 	}
 
 	mdRenderer, err := renderer.NewRenderer(rendererOpts)

--- a/internal/renderer/markdown.go
+++ b/internal/renderer/markdown.go
@@ -9,11 +9,12 @@ import (
 
 // RenderOptions contains configuration for rendering markdown
 type RenderOptions struct {
-	Style         string // Style name: "dark", "light", "auto"
-	Width         int    // Terminal width for wrapping
-	NoMermaid     bool   // Skip mermaid diagram detection
-	MermaidMode   string // Mermaid rendering mode: "terminal", "svg", "url"
-	MermaidOutDir string // Output directory for SVG files
+	Style            string // Style name: "dark", "light", "auto"
+	Width            int    // Terminal width for wrapping
+	NoMermaid        bool   // Skip mermaid diagram detection
+	MermaidMode      string // Mermaid rendering mode: "terminal", "svg", "url"
+	MermaidOutDir    string // Output directory for SVG files
+	KeepMermaidFiles bool   // Save mermaid diagram files to disk
 }
 
 // Renderer handles markdown rendering

--- a/internal/viewer/simple.go
+++ b/internal/viewer/simple.go
@@ -130,13 +130,15 @@ func (v *SimpleViewer) renderMermaidDiagrams(content []byte) error {
 				fmt.Print("\n" + preview)
 			}
 			
-			// Save to file
-			filename := fmt.Sprintf("diagram-%d.svg", i+1)
-			outputPath := filepath.Join(opts.MermaidOutDir, filename)
-			if err := mermaid.SaveSVGToFile(result.SVG, outputPath); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: failed to save SVG: %v\n", err)
-			} else {
-				fmt.Printf("  💾 Saved to: %s\n\n", outputPath)
+			// Save to file only if --keep-mermaid-files is set
+			if opts.KeepMermaidFiles {
+				filename := fmt.Sprintf("diagram-%d.svg", i+1)
+				outputPath := filepath.Join(opts.MermaidOutDir, filename)
+				if err := mermaid.SaveSVGToFile(result.SVG, outputPath); err != nil {
+					fmt.Fprintf(os.Stderr, "Warning: failed to save SVG: %v\n", err)
+				} else {
+					fmt.Printf("  💾 Saved to: %s\n\n", outputPath)
+				}
 			}
 			
 		case "svg":


### PR DESCRIPTION
## Summary
This PR implements a memory-only rendering mode for Mermaid diagrams in terminal viewing, eliminating filesystem pollution while maintaining the option to save files when needed.

## Changes
- **Memory-only terminal mode**: By default, terminal mode now works entirely in memory with no files created
- **New flag**: `--keep-mermaid-files` (`-k`) to save diagram files when explicitly desired
- **Default output directory**: Changed from current directory (`.`) to system temp directory (`os.TempDir()`)
- **Updated documentation**: README.md and WARP.md now reflect the new behavior
- **Added WARP.md**: Comprehensive guidance for future Warp AI agents working in this repository

## Benefits
✅ **No filesystem pollution**: Terminal viewing no longer creates unwanted files  
✅ **Better performance**: Eliminates disk I/O overhead  
✅ **Privacy**: Diagrams stay in memory during viewing  
✅ **Cleaner workspace**: No leftover diagram files cluttering directories  

## Behavior by Mode
- **Terminal mode** (`--mermaid-mode=terminal`): Memory-only by default, save with `-k`
- **SVG export** (`--mermaid-mode=svg`): Always saves files (unchanged)
- **PNG export** (`--mermaid-mode=png`): Always saves files (unchanged)
- **URL mode** (`--mermaid-mode=url`): No files (unchanged)

## Breaking Change ⚠️
Users who relied on automatic file generation in terminal mode must now use the `--keep-mermaid-files` flag.

## Testing
Manually tested:
- ✅ Terminal mode without flag: No files created
- ✅ Terminal mode with `-k`: Files saved to temp directory
- ✅ Terminal mode with `-k --mermaid-output-dir=./custom`: Files saved to custom directory
- ✅ SVG/PNG export modes: Files always saved
- ✅ Multiple diagrams: All handled consistently

## Examples
```bash
# View without creating files (new default)
mdviewer README.md

# Save diagrams to temp directory
mdviewer README.md --keep-mermaid-files

# Save diagrams to custom directory
mdviewer README.md -k --mermaid-output-dir=./diagrams
```